### PR TITLE
Fix date sorting in Central Park Private Volunteering bot

### DIFF
--- a/daily_update_lambda/central_park_private_volunteering_bot.py
+++ b/daily_update_lambda/central_park_private_volunteering_bot.py
@@ -107,13 +107,14 @@ class CentralParkPrivateVolunteeringBot:
             by_date[opp.get("date", "")].append(opp)
 
         def _parse_sort_key(date_str: str):
-            """Parse date for sorting. Returns (datetime, original) - unparseable go last."""
+            """Parse date for sorting. Returns datetime - unparseable go last."""
             for fmt in CentralParkPrivateVolunteeringBot.DATE_FORMATS:
                 try:
                     return datetime.strptime(date_str.strip(), fmt)
                 except ValueError:
                     continue
-            return (datetime.max, date_str)
+            logger.warning("Could not parse date '%s' - it will be sorted to the end of the list", date_str)
+            return datetime.max
 
         table_rows = ""
         for date in sorted(by_date.keys(), key=_parse_sort_key):


### PR DESCRIPTION
Fixes #2

Changed `_parse_sort_key` function to consistently return datetime objects instead of mixed types (datetime or tuple). Added helpful warning log when dates cannot be parsed. This fixes the sorting issue where dates were not being properly ordered chronologically.

Generated with [Claude Code](https://claude.ai/code)